### PR TITLE
A better suggestion about the annotation usage

### DIFF
--- a/one-sys/src/main/java/com/lcw/one/sys/dao/BaseTemplateEODao.java
+++ b/one-sys/src/main/java/com/lcw/one/sys/dao/BaseTemplateEODao.java
@@ -4,12 +4,12 @@ import com.lcw.one.baseInfo.entity.BaseTemplateEO;
 import com.lcw.one.util.persistence.BaseRepositoryImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.repository.support.JpaEntityInformationSupport;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
 import java.util.List;
 
-@Component
+@Repository
 public class BaseTemplateEODao extends BaseRepositoryImpl<BaseTemplateEO, String> {
 
     @Autowired


### PR DESCRIPTION
Hi, I found that there may be some minor improvements about annotations in your code. 

A Spring bean in the persistence layer should be annotated using @Repository instead of @Component annotation.
@Repository annotation is a specialization of @Component in persistence layer. By using a specialized annotation we hit two birds with one stone. First, they are treated as Spring bean, and second, you can put special behavior required by that layer.

For better understanding and maintainability of a large application, @Repository is a better choice.